### PR TITLE
Proposal

### DIFF
--- a/revision/architecture.md
+++ b/revision/architecture.md
@@ -124,7 +124,8 @@ Quels sont les 5 bridges vers des librairies externes inclus dans Symfony ?
 Configuration
 ----------
 Quels sont les formats de configuration supportés par Symfony par défaut ?
-> xml, yml, php, ini et annotation
+> xml, yml, php, ini
+> Annotation can only be used for Controllers this is provided by SensioExtraFrameworkBundle https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/index.html#annotations-for-controllers
 
 Parmi ces formats, lequel est le plus performant ?
 > aucun, ils sont tous compilés en PHP avant l'exécution de l'application


### PR DESCRIPTION
Quels sont les formats de configuration supportés par Symfony par défaut ?
> xml, yml, php, ini et annotation

By default config component supports http://symfony.com/doc/3.0/components/config.html -> YAML, XML, INI files
You can also load php in configuring your app https://symfony.com/doc/current/configuration.html#configuration-config-yml You can also mix resource ex. by loading from YAML file php files https://symfony.com/doc/current/configuration/configuration_organization.html#mix-and-match-configuration-formats

Annotation can only be used for Controllers this is provided by SensioExtraFrameworkBundle https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/index.html#annotations-for-controllers